### PR TITLE
Drop Ruby 1.9.3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Changes
+- Minimum Ruby runtime version is now 2.0 (@eheydrick)
 
 ## [1.0.0] - 2017-06-26
 ### Added

--- a/sensu-plugins-growthforecast.gemspec
+++ b/sensu-plugins-growthforecast.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   s.summary                = 'Sensu plugins for growthforecast'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsGrowthForecast::Version::VER_STRING


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Existing tests pass

#### Purpose

Drop 1.9.3 support.

#### Known Compatibility Issues

Ruby 2.0 required now.
